### PR TITLE
 Issue #SB-7915, fix: ques not rendering properly on replay from endpage.

### DIFF
--- a/renderer/components/js/components.js
+++ b/renderer/components/js/components.js
@@ -4,10 +4,20 @@ org.ekstep.questionunit.baseComponent = {
         EkstepRendererAPI.dispatchEvent('org.ekstep.questionunit:playaudio', audioObj)
     },
     loadImageFromUrl: function (element, imgUrl, pluginId, pluginVer) {
-        EkstepRendererAPI.dispatchEvent('org.ekstep.questionunit:loadimagefromurl', { 'element': element, 'path': imgUrl, 'pluginId': pluginId, 'pluginVer': pluginVer });
+        EkstepRendererAPI.dispatchEvent('org.ekstep.questionunit:loadimagefromurl', {
+            'element': element,
+            'path': imgUrl,
+            'pluginId': pluginId,
+            'pluginVer': pluginVer
+        });
     },
-    loadAssetUrl: function(element, imgUrl, pluginId, pluginVer){
-        EkstepRendererAPI.dispatchEvent('org.ekstep.questionunit:loadAssetUrl', { 'element': element, 'path': imgUrl, 'pluginId': pluginId, 'pluginVer': pluginVer });
+    loadAssetUrl: function (element, imgUrl, pluginId, pluginVer) {
+        EkstepRendererAPI.dispatchEvent('org.ekstep.questionunit:loadAssetUrl', {
+            'element': element,
+            'path': imgUrl,
+            'pluginId': pluginId,
+            'pluginVer': pluginVer
+        });
     },
     generateModelTemplate: function () {
         return "<div class='popup' id='image-model-popup' onclick='org.ekstep.questionunit.questionComponent.hideImageModel()'><div class='popup-overlay' onclick='org.ekstep.questionunit.questionComponent.hideImageModel()'></div> \
@@ -19,11 +29,11 @@ org.ekstep.questionunit.baseComponent = {
         </div>"
     },
     showImageModel: function (event, imageSrc, elementId) {
-        if(elementId){
-            imageSrc = $("#"+elementId).attr('src');
+        if (elementId) {
+            imageSrc = $("#" + elementId).attr('src');
         }
 
-        if(imageSrc){
+        if (imageSrc) {
             var modelTemplate = this.generateModelTemplate();
             var template = _.template(modelTemplate);
             var templateData = template({
@@ -66,13 +76,52 @@ org.ekstep.questionunit.questionComponent = {
         ';
     },
     isQuestionTextOverflow: function () {
-        if ($('.hiding-container').height() > $('.expand-container').height()) {
-            $('.expand-button').css('display', 'none');
-            $('.hiding-container').addClass('absolute-center');
-            $('.hiding-container').css('height', '100%');
-        } else {
-            $('.expand-button').css('display', 'block');
+        // This method's definition is based on this article,
+        // https://blog.lavrton.com/javascript-loops-how-to-handle-async-await-6252dd3c795
+
+        // creating an array to iterate over.
+        var arr = _.range(10);
+
+        // This method checks if the dom element has proper height,
+        // if yes then it applies appropriate css.
+        // It returns a promise.
+        function check(iteration) {
+            return new Promise(function (resolve) {
+                if ($('.expand-container').height() === 0) {
+                    resolve(false)
+                } else {
+                    // CSS to be applied
+                    if ($('.hiding-container').height() > $('.expand-container').height()) {
+                        $('.expand-button').css('display', 'none');
+                        $('.hiding-container').addClass('absolute-center');
+                        $('.hiding-container').css('height', '100%');
+                    } else {
+                        $('.expand-button').css('display', 'block');
+                    }
+                    resolve(true);
+                }
+            })
         }
+
+        // This is an async method which calls the check() method (max defined by arr array)
+        async function process() {
+            for (const i of arr) {
+                try {
+                    var res = await check(i);
+                    if (res) {
+                        console.log('iteration -> ' + (i + 1) + ' -> RESOLVED!!!');
+                        break;
+                    } else {
+                        throw new Error('iteration -> ' + (i + 1) + ' -> NOT resolved')
+                    }
+                } catch (err) {
+                    console.log(err)
+                }
+            }
+        }
+
+        // start process
+        process();
     },
     toggleQuestionText: function () {
         if ($('.hiding-container').hasClass('expanded')) {
@@ -97,7 +146,7 @@ org.ekstep.questionunit.questionComponent = {
         this.isQuestionTextOverflow();
         org.ekstep.questionunit.questionComponent.loadImageFromUrl($('#org-ekstep-contentrenderer-questionunit-questionComponent-downArwImg'), 'renderer/assets/down_arrow.png', 'org.ekstep.questionunit', '1.0');
         org.ekstep.questionunit.questionComponent.loadImageFromUrl($('#org-ekstep-contentrenderer-questionunit-questionComponent-AudioImg'), 'renderer/assets/audio-icon.png', 'org.ekstep.questionunit', '1.0');
-        org.ekstep.questionunit.questionComponent.loadAssetUrl($('#org-ekstep-questionunit-questionComponent-qimage'),$('#org-ekstep-questionunit-questionComponent-qimage').data('image'), 'org.ekstep.questionunit', '1.0');
+        org.ekstep.questionunit.questionComponent.loadAssetUrl($('#org-ekstep-questionunit-questionComponent-qimage'), $('#org-ekstep-questionunit-questionComponent-qimage').data('image'), 'org.ekstep.questionunit', '1.0');
     }
 }
 jQuery.extend(org.ekstep.questionunit.questionComponent, org.ekstep.questionunit.baseComponent);

--- a/renderer/components/js/components.js
+++ b/renderer/components/js/components.js
@@ -70,58 +70,21 @@ org.ekstep.questionunit.questionComponent = {
                 </div>\
             </div>\
             <div class="expand-button" onclick="org.ekstep.questionunit.questionComponent.toggleQuestionText()">\
-                <img src="" id="org-ekstep-contentrenderer-questionunit-questionComponent-downArwImg"/>\
+                <img class="exp-button" src="" id="org-ekstep-contentrenderer-questionunit-questionComponent-downArwImg"/>\
             </div>\
         </div><script>org.ekstep.questionunit.questionComponent.onDomReady();</script>\
         ';
     },
     isQuestionTextOverflow: function () {
-        // This method's definition is based on this article,
-        // https://blog.lavrton.com/javascript-loops-how-to-handle-async-await-6252dd3c795
-
-        // creating an array to iterate over.
-        var arr = _.range(10);
-
-        // This method checks if the dom element has proper height,
-        // if yes then it applies appropriate css.
-        // It returns a promise.
-        function check(iteration) {
-            return new Promise(function (resolve) {
-                if ($('.expand-container').height() === 0) {
-                    resolve(false)
-                } else {
-                    // CSS to be applied
-                    if ($('.hiding-container').height() > $('.expand-container').height()) {
-                        $('.expand-button').css('display', 'none');
-                        $('.hiding-container').addClass('absolute-center');
-                        $('.hiding-container').css('height', '100%');
-                    } else {
-                        $('.expand-button').css('display', 'block');
-                    }
-                    resolve(true);
-                }
-            })
-        }
-
-        // This is an async method which calls the check() method (max defined by arr array)
-        async function process() {
-            for (const i of arr) {
-                try {
-                    var res = await check(i);
-                    if (res) {
-                        console.log('iteration -> ' + (i + 1) + ' -> RESOLVED!!!');
-                        break;
-                    } else {
-                        throw new Error('iteration -> ' + (i + 1) + ' -> NOT resolved')
-                    }
-                } catch (err) {
-                    console.log(err)
-                }
+        $('.exp-button').on("load", function () {
+            if ($('.hiding-container').height() > $('.expand-container').height()) {
+                $('.expand-button').css('display', 'none');
+                $('.hiding-container').addClass('absolute-center');
+                $('.hiding-container').css('height', '100%');
+            } else {
+                $('.expand-button').css('display', 'block');
             }
-        }
-
-        // start process
-        process();
+        })
     },
     toggleQuestionText: function () {
         if ($('.hiding-container').hasClass('expanded')) {
@@ -167,3 +130,4 @@ org.ekstep.questionunit.backgroundComponent = {
 };
 
 //# sourceURL=org.ekstep.questionunit.components.js
+//https://staging.open-sunbird.org/workspace/content/edit/content/do_2126328762311393281974/allcontent/NCF#no


### PR DESCRIPTION
Fix for https://project-sunbird.atlassian.net/browse/SB-7915

This would be a **partial** fix as it works well for question text **without any math-text**.

But it doesn't work well for math-text as the katex library adds extra bottom and top padding automatically, which takes some rendering time.

snapshots after fix
![image](https://user-images.githubusercontent.com/28862428/49573691-a419cc00-f964-11e8-896b-98f4316698e0.png)
![image](https://user-images.githubusercontent.com/28862428/49573754-c6abe500-f964-11e8-8d65-65bd83fb2ee0.png)

scenario which doesn't work 
![image](https://user-images.githubusercontent.com/28862428/49573863-0b378080-f965-11e8-848d-fd0f51113d6e.png)

but when the text is long enough, there is no issue.
![image](https://user-images.githubusercontent.com/28862428/49573925-33bf7a80-f965-11e8-93e8-187d667ce291.png)
![image](https://user-images.githubusercontent.com/28862428/49573955-41750000-f965-11e8-9a86-df7d3fc644e9.png)
